### PR TITLE
ADD fix to filter not reloading

### DIFF
--- a/lib/features/worker/screens/listjobs/list_jobs.dart
+++ b/lib/features/worker/screens/listjobs/list_jobs.dart
@@ -71,6 +71,7 @@ class _ListJobsState extends State<ListJobs> {
     });
   }
 
+
   void _addFilter(FilterStatus status, String value) {
     setState(() {
       activeFilters[status] = value;
@@ -81,27 +82,37 @@ class _ListJobsState extends State<ListJobs> {
     FilterStatus? selected = await showDialog<FilterStatus>(
       context: context,
       builder: (BuildContext dialogContext) {
-        return SimpleDialog(
-          title: const Text("Select a filter"),
-          children: [
-            ...FilterStatus.values.map(
-              (status) => SimpleDialogOption(
-                onPressed: () => Navigator.pop(dialogContext, status),
-                child: Text(status.toString().split('.').last),
-              ),
-            ),
-            buildFilterBox(activeFilters, _onDeleted),
-          ],
+        return StatefulBuilder(
+          builder: (BuildContext dialogContext, void Function(void Function()) setState) {
+            return SimpleDialog(
+              title: const Text("Select a filter"),
+              children: [
+                ...FilterStatus.values.map(
+                  (status) => SimpleDialogOption(
+                    onPressed: () => Navigator.pop(dialogContext, status),
+                    child: Text(status.toString().split('.').last),
+                  ),
+                ),
+                buildFilterBox(activeFilters, (status) {
+                  setState(() {
+                    activeFilters.remove(status as FilterStatus);
+                  });
+                  _onDeleted(status);
+                }),
+              ],
+            );
+          },
         );
       },
     );
 
     if (selected != null && mounted) {
       showFilterDialog(context, selected, (value) {
-        _addFilter(selected, value);
+        if (value.isNotEmpty) _addFilter(selected, value);
       });
     }
   }
+
 
   bool returnValue(String filterValue, String jobValue, String filterKey) {
     switch (filterKey) {


### PR DESCRIPTION
This pull request includes updates to the `lib/features/worker/screens/listjobs/list_jobs.dart` file, specifically enhancing the filter functionality in the `_ListJobsState` class. The main changes involve adding a `StatefulBuilder` to the filter dialog and improving how filters are managed and removed.

Enhancements to filter functionality:

* Added `StatefulBuilder` to the filter dialog to allow dynamic updates within the dialog.
* Modified the `buildFilterBox` method to include a `setState` call when removing filters, ensuring the UI updates correctly when a filter is deleted.

These changes improve the user experience by allowing real-time updates and better management of filters in the job listing screen.